### PR TITLE
Added other badge styles

### DIFF
--- a/resources/assets/docs/status-badges.md
+++ b/resources/assets/docs/status-badges.md
@@ -11,8 +11,10 @@ README, a dashboard, or anywhere else you can imagine!
 Here's our current build status:
 ![](https://circleci.com/gh/circleci/circle.png?circle-token=3cc80b12ab3627373c76e13735b8bc00a1259b9e)</img>
 
-The status images are also available in "shield" style:
+The status images are also available in "shield" style, "flat" style and "flat-square" style:
 ![](https://circleci.com/gh/circleci/circle.svg?style=shield&circle-token=3cc80b12ab3627373c76e13735b8bc00a1259b9e)</img>
+![](https://circleci.com/gh/circleci/circle.svg?style=flat&circle-token=3cc80b12ab3627373c76e13735b8bc00a1259b9e)</img>
+![](https://circleci.com/gh/circleci/circle.svg?style=flat-square&circle-token=3cc80b12ab3627373c76e13735b8bc00a1259b9e)</img>
 
 In the project settings for each of your repositories, there's a "Status Badges" section that can generate code for Markdown, rst, etc.  Or if you want to tweak them manually, how they work is straightforward:
 

--- a/src-cljs/frontend/components/project_settings.cljs
+++ b/src-cljs/frontend/components/project_settings.cljs
@@ -613,6 +613,8 @@
 (def status-styles
   {"badge" {:label "Badge" :string ".png?style=badge"}
    "shield" {:label "Shield" :string ".svg?style=shield"}
+   "flat" {:label "Flat" :string ".svg?style=flat"}
+   "flat-square" {:label "FlatSquare" :string ".svg?style=flat-square"}
    "svg" {:label "Badge" :string ".svg?style=svg"}})
 
 (def status-formats


### PR DESCRIPTION
This is not ready to merge. I have never written Clojure before.

Basically I would like to add extra style options to the badges.

This is the default one
![](https://circleci.com/gh/madewithlove/elasticsearcher.svg)

This is `?style=svg`

![](https://circleci.com/gh/madewithlove/elasticsearcher.svg?style=svg)

And this is `?style=shield`

![](https://circleci.com/gh/madewithlove/elasticsearcher.svg?style=shield)

It would be easy to add two new styles `flat` and `flat-square` by leveraging the power of [shields.io](http://shields.io)

Todo: add these styles. All you need to do is to forward the source, or redirect the client with a `302 Found`.

This is `?style=flat`

![](https://img.shields.io/badge/circleci-failing-red.svg?style=flat) ![](https://img.shields.io/badge/circleci-passing-green.svg?style=flat)

And this is `?style=flat-square`

![](https://img.shields.io/badge/circleci-failing-red.svg?style=flat-square) ![](https://img.shields.io/badge/circleci-passing-green.svg?style=flat-square)