### PR TITLE
Use sentinel to make select-in work w/ falsey values

### DIFF
--- a/src-cljs/frontend/utils/seq.cljs
+++ b/src-cljs/frontend/utils/seq.cljs
@@ -5,17 +5,19 @@
   [filter-fn coll]
   (first (keep-indexed (fn [i x] (when (filter-fn x) i)) coll)))
 
+(def sentinel (js-obj))
+
 (defn select-in
   "Returns a map containing only those entries in map whose keypath is in keypaths
    (select-in {:a {:b 1 :c 2}} [[:a :b]]) => {:a {:b 1}} "
   [map keypathseq]
     (loop [ret {} keypaths (seq keypathseq)]
       (if keypaths
-        (let [entry (get-in map (first keypaths))]
+        (let [entry (get-in map (first keypaths) sentinel)]
           (recur
-           (if entry
-             (assoc-in ret (first keypaths) entry)
-             ret)
+           (if (identical? entry sentinel)
+             ret
+             (assoc-in ret (first keypaths) entry))
            (next keypaths)))
         (with-meta ret (meta map)))))
 


### PR DESCRIPTION
(select-in {:a false} [[:a]]) should return {:a false} instead of {}