### PR TITLE
Use an empty version of the map passed to select-in

### DIFF
--- a/src-cljs/frontend/utils/seq.cljs
+++ b/src-cljs/frontend/utils/seq.cljs
@@ -11,7 +11,7 @@
   "Returns a map containing only those entries in map whose keypath is in keypaths
    (select-in {:a {:b 1 :c 2}} [[:a :b]]) => {:a {:b 1}} "
   [map keypathseq]
-    (loop [ret {} keypaths (seq keypathseq)]
+    (loop [ret (empty map) keypaths (seq keypathseq)]
       (if keypaths
         (let [entry (get-in map (first keypaths) sentinel)]
           (recur


### PR DESCRIPTION
Another fix for select-in. This will preserve Om cursors when you use select-in.