### PR TITLE
Clarification on when exactly caching happens.

### DIFF
--- a/resources/assets/docs/configuration.md
+++ b/resources/assets/docs/configuration.md
@@ -380,6 +380,8 @@ dependencies:
     - "~/assets/output" # relative to the user's home directory
 ```
 
+Caching happens after the dependency step, so the directories that are specified in `cache_directories` must be available before then.
+
 Caches are private, and are not shared with other projects.
 
 <h2 id="database">Database setup</h2>


### PR DESCRIPTION
The current documentation does not mention exactly when caching happens.

I spent a quite bit of time trying to figure out why some directories were not caching. They were created during the deployment step. Thanks to @startling for the information.