### PR TITLE
Improve hint about private Email in invite

### DIFF
--- a/src-cljs/frontend/components/invites.cljs
+++ b/src-cljs/frontend/components/invites.cljs
@@ -36,8 +36,9 @@
                     :value email
                     :id (str login "-email")}]
            [:label {:for (str login "-email")}
-            [:i.fa.fa-exclamation-circle]
-            " Fix Email"]]
+            [:i.fa.fa-exclamation-circle
+             {:title "Entering an Email address is required for sending invites to this user"}]
+            " Email not available"]]
           [:label.invite-select {:id (str login "-label")
                                  :for (str login "-checkbox")}
            [:input {:type "checkbox"


### PR DESCRIPTION
Whenever a user has set his Email in GitHub to private,
this user can't be invited without providing an Email address.
This is now explained more clearly.