### PR TITLE
Center the Sign in Button on the Public Build Status Page

### DIFF
--- a/src-cljs/frontend/components/header.cljs
+++ b/src-cljs/frontend/components/header.cljs
@@ -205,7 +205,7 @@
                                       :title "Log In with Github"}
                  "Log In"]]
                [:li
-                [:button.login-link.btn.btn-success {:href (auth-url)
+                [:button.login-link.btn.btn-success.navbar-btn {:href (auth-url)
                                                      :on-click #(raise! owner [:track-external-link-clicked {:path (auth-url) :event "signup_click" :properties {:source "header sign-up" :url js/window.location.pathname}}])
                                                      :title "Sign up with Github"}
                  "Sign Up"]]])]]


### PR DESCRIPTION
Tested this locally in an LXC container and worked fine.  Hope it will work for you as well!  :-)