### PR TITLE
Updated Documentation to Use HTTPS instead of HTTP

### DIFF
--- a/resources/assets/docs/git-bundle-install.md
+++ b/resources/assets/docs/git-bundle-install.md
@@ -21,10 +21,10 @@ gem "rails", :git => "git://github.com/rails/rails.git"
 ```
 
 If the repository is public, just change the dependency to use a
-`http` url:
+`https` url:
 
 ```
-gem "rails", :git => "http://github.com/rails/rails"
+gem "rails", :git => "https://github.com/rails/rails"
 ```
 
 If the repository is private, you will need to enable user keys


### PR DESCRIPTION
This was a suggestion made by someone on Twitter[1], and I think that HTTPS is the way to go. :) 

[1]https://twitter.com/KrauseFx/status/619919006707941376 