### PR TITLE
Add information about running tests in multiple PHP versions

### DIFF
--- a/resources/assets/docs/configuration.md
+++ b/resources/assets/docs/configuration.md
@@ -250,6 +250,27 @@ machine:
 
 See [supported PHP versions](/docs/environment#php) for a complete list.
 
+It is also possible to run your unit tests in different PHP versions by
+switching the php version after running the tests, and then calling 
+your tests again. Here's an example of how that might work:
+
+```
+machine:
+  php:
+    version: 5.4.5
+test:
+  post:
+    - phpenv local 5.4.37 && php -v
+    - phpunit
+    - phpenv local 5.5.21 && php -v
+    - phpunit
+    - phpenv local 5.6.5 && php -v
+    - phpunit
+```
+
+With this example, your tests are initially run in PHP 5.4.5, followed by
+5.4.37, 5.5.21 and 5.6.5.
+
 ### Python version
 
 CircleCI uses [pyenv](https://github.com/yyuu/pyenv)


### PR DESCRIPTION
Initially I was told via support it wasn't possible to run tests across multiple php versions, but as phpenv is used for managing the active PHP version and there are a lot of different versions installed, this turns out to be super easy. 

The only downside is that these are run in sequence and there's no fancy test matrix that shows the status of the tests across the different versions, but given any failed command marks the build as failed it is perfectly capable of showing you when something is wrong.