### PR TITLE
More straight jackets in the FB analytics code

### DIFF
--- a/src-cljs/frontend/analytics/facebook.cljs
+++ b/src-cljs/frontend/analytics/facebook.cljs
@@ -3,7 +3,8 @@
             [goog.net.jsloader]))
 
 (defn track-conversion []
-  (.push js/window._fbq #js ["track" "6017370234581" {:value "0.01" :currency "USD"}]))
+  (utils/swallow-errors
+    (.push js/window._fbq #js ["track" "6017370234581" {:value "0.01" :currency "USD"}])))
 
 (defn track-signup []
   (utils/swallow-errors
@@ -11,4 +12,3 @@
       (track-conversion)
       (-> (goog.net.jsloader.load "//connect.facebook.net/en_US/fbds.js")
           (.addCallback track-conversion)))))
-  


### PR DESCRIPTION
It was somehow causing orgs to stop loading when the callback on the goog.net.jsloader fired.

To test, block FB on CircleCI with ghostery and visit the /add-projects page. Before this change, you should see an infinite spinner. After the change, things should work normally.