### PR TITLE
Re-use feature-flag-key-name when searching the query string

### DIFF
--- a/src-cljs/frontend/models/feature.cljs
+++ b/src-cljs/frontend/models/feature.cljs
@@ -24,7 +24,7 @@
       str
       goog.Uri.parse
       .getQueryData
-      (.get (str "feature-" (name feature)))))
+      (.get (feature-flag-key-name feature))))
 
 (defn set-in-query-string? [feature]
   (some? (get-in-query-string feature)))


### PR DESCRIPTION
**Rationale**
There was a small duplication of logic in `src-cljs/frontend/models/feature.cljs` , the change just re-use the function already implemented. 

It's only a minor refactoring, the UI is not impacted.

Thanks for the project!