### PR TITLE
Add status badge template for Org READMEs

### DIFF
--- a/src-cljs/frontend/components/project_settings.cljs
+++ b/src-cljs/frontend/components/project_settings.cljs
@@ -1222,6 +1222,8 @@
             :template :image}
    "markdown" {:label "Markdown"
                :template #(str "[![CircleCI](" (:image %) ")](" (:target %) ")")}
+   "org" {:label "Org"
+          :template #(str "[[" (:target %) "][" (:image %) "]]")}
    "textile" {:label "Textile"
               :template #(str "!" (:image %) "!:" (:target %))}
    "rdoc" {:label "Rdoc"


### PR DESCRIPTION
GitHub renders project READMEs written in Org format.
Example: https://github.com/jkrmr/dagger/blob/master/README.org

This patch adds an Org-formatted template for the build status badge to the build settings panel.

**Rationale**

Make it easy for users to add status badges to their README when it's formatted as an Org document.

**Considerations**

I'm not aware of any good way to add an alt tag to GitHub's rendered HTML via Org markup.

**Before**
<img width="377" alt="before" src="https://user-images.githubusercontent.com/4433943/28079898-0b1533a2-6638-11e7-965c-7f6a404a597c.png">

**After**

<img width="376" alt="after1" src="https://user-images.githubusercontent.com/4433943/28079901-0f85f4b2-6638-11e7-8f82-939710b75214.png">

<img width="661" alt="after" src="https://user-images.githubusercontent.com/4433943/28079819-ce86525e-6637-11e7-9109-8e0379f2098a.png">

**Rendered**

<img width="661" alt="screen shot 2017-07-11 at 12 50 53 pm" src="https://user-images.githubusercontent.com/4433943/28079810-c517287e-6637-11e7-9d6b-300d2ee18bda.png">

cc
@nwjsmith 
