### PR TITLE
Update project settings for circleci 2.0

### DIFF
--- a/src-cljs/frontend/components/project_settings.cljs
+++ b/src-cljs/frontend/components/project_settings.cljs
@@ -119,14 +119,14 @@
                   {:title (str "How to configure " (vcs-url/project-name (get-in project-data [:project :vcs_url])))}
                   (html
                     [:div
-                     [:b "Option 1"]
-                     [:p "Do nothing! CircleCI infers many settings automatically. Works great for Ruby, Python, NodeJS, Java and Clojure. However, if it needs tweaks or doesn't work, see below."]
-                     [:b "Option 2"]
-                     [:p
-                      "Override inferred settings and add new test commands "
+                     [:p "After August 31, 2018, CircleCI 1.0 will no longer be available for Linux and macOS users. You can find guides for transitioning from 1.0 to 2.0 and a full timeline on planned changes " [:a {:href "https://circleci.com/sunset1-0/"} "here"]]
+                     [:b "CircleCI 2.0"]
+                     [:p "Effective with CircleCI 2.0, all configuration is captured in the project's "[:a {:href "https://circleci.com/docs/2.0/configuration-reference/"} ".circleci/config.yml file"] ]
+                     [:b "CircleCI 1.0 - Option 1"]
+                     [:p "Override inferred settings and add new test commands "
                       [:a {:href "#setup"} "through the web UI"]
                       ". This works great for prototyping changes."]
-                     [:b "Option 3"]
+                     [:b "CircleCI 1.0 - Option 2"]
                      [:p
                       "Override all settings via a "
                       [:a {:href "https://circleci.com/docs/configuration/"} "circle.yml file"]


### PR DESCRIPTION
Noticed report in https://discuss.circleci.com/t/step-3-on-edit-project-settings-project-overview-needs-update/21245

Project settings is specific to 1.0.  These edits remind users of pending retirement, and prioritize 2.0 instructions.

**Rationale**
This PR addresses omission in Project Settings page that still uses circleci 1.0 links and references.

**Considerations**
* Page had  no mention of the 1.0/2.0 distinctions or retirement.
* The page's "Option 3" is the only valid option moving forward, but links to old 1.0 docs
* Users are reporting bugs 

**Ticket:** [Discuss Bug Report](https://discuss.circleci.com/t/step-3-on-edit-project-settings-project-overview-needs-update/21245)

**Before**
<img width="1007" alt="screen shot 2018-04-11 at 8 02 17 pm" src="https://user-images.githubusercontent.com/5262154/38649211-57640518-3dc3-11e8-9026-eb8c628fd333.png">


**After**
<img width="1003" alt="screen shot 2018-04-11 at 8 09 35 pm" src="https://user-images.githubusercontent.com/5262154/38649394-489fcc32-3dc4-11e8-88c1-1093dc8ca891.png">

