### PR TITLE
add 1x concurrency for open source

### DIFF
--- a/src-cljs/frontend/components/org_settings.cljs
+++ b/src-cljs/frontend/components/org_settings.cljs
@@ -284,7 +284,7 @@
               [:a {:href "mailto:billing@circleci.com"} "billing@circleci.com"]]]}
 
    {:question "What if I am building open-source?"
-    :answer [[:div "We also offer the Seed plan for OS X open-source projects. Contact us at "
+    :answer [[:div "We also offer the Seed plan (at 1x concurrency) for OS X open-source projects. Contact us at "
               [:a {:href "mailto:billing@circleci.com"} "billing@circleci.com"]
               " for access. If you are building a bigger open-source project and need more resources, let us know how we can help you!"]]}])
 


### PR DESCRIPTION
**Rationale**
OSX open source plans only have 1x concurrency, instead of 2x that the paid seed plan offers. 

**Considerations**
We've received a few tickets related to this.

**Ticket:** https://circleci.zendesk.com/agent/tickets/41182

