### PR TITLE
Fix typo - README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ To have a process watch for changes and run the tests every time you make change
 lein doo chrome dev-test auto
 ```
 
-The default option is `auto`, so it will run in that state if you ommit that argument. You can also use `phantom `, `firefox`, and a variety of our js enviornments to run the tests on. For full documentation read [lein doo's README](https://github.com/bensu/doo/)
+The default option is `auto`, so it will run in that state if you omit that argument. You can also use `phantom `, `firefox`, and a variety of our js enviornments to run the tests on. For full documentation read [lein doo's README](https://github.com/bensu/doo/)
 
 ### Adding Tests
 


### PR DESCRIPTION
Fixed 'omit' 's spelling.
Changed from 'ommit' to 'omit'
Minor typo - should be merged flawlessly.

**Rationale**
Enhance README.md

**Considerations**
* Fixed typo. Changed 'ommit' to 'omit'

**Ticket:** [CIRCLE-XXXX](https://circleci.atlassian.net/browse/CIRCLE-XXXX)

**image showing changes**
![temp](https://user-images.githubusercontent.com/25405707/67551541-d243fe00-f726-11e9-85b1-e17b54b7bfb9.PNG)

